### PR TITLE
Pitch: identifiable sections

### DIFF
--- a/Sample/Sample/Models/DataSources/ArrayBackedDataSource.swift
+++ b/Sample/Sample/Models/DataSources/ArrayBackedDataSource.swift
@@ -8,10 +8,17 @@
 
 import Shinkansen
 
-struct ArrayBackedDataSource: SectionDataSource {
-    let items: [String]
+class ArrayBackedDataSource<Item>: SectionDataSource {
+
+    private weak var conductor: DataSourceConductor?
+
+    private(set) var items: [Item]
+
+    init(items: [Item]) {
+        self.items = items
+    }
 
     func setConductor(_ conductor: DataSourceConductor) {
-        // Unused
+        self.conductor = conductor
     }
 }

--- a/Sample/Sample/ViewControllers/DetailViewController.swift
+++ b/Sample/Sample/ViewControllers/DetailViewController.swift
@@ -10,7 +10,12 @@ import UIKit
 import Shinkansen
 
 class DetailViewController: UICollectionViewController {
-    private let shinkansen = CollectionViewShinkansen()
+
+    enum Section {
+        case bands
+    }
+
+    private let shinkansen = CollectionViewShinkansen<Section>()
 
     init(title: String) {
         let layout = UICollectionViewFlowLayout()
@@ -49,8 +54,8 @@ class DetailViewController: UICollectionViewController {
 // MARK: - Configure bands section
 extension DetailViewController {
     func configureBandsSection() {
-        let bandsSection = shinkansen.createSection(
-            from: ArrayBackedDataSource(items: ["Metallica", "Slayer"]),
+        let bandsSection = CollectionViewDataSourceSection(
+            dataSource: ArrayBackedDataSource(items: ["Metallica", "Slayer"]),
             cellConfigurator: { collectionView, bandName, indexPath in
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "TextCell", for: indexPath) as! SimpleTextCollectionViewCell
                 cell.text = bandName
@@ -74,5 +79,7 @@ extension DetailViewController {
 
             return cell
         })
+
+        shinkansen.connectSection(bandsSection, identifiedBy: .bands)
     }
 }

--- a/Sample/Sample/ViewControllers/ViewController.swift
+++ b/Sample/Sample/ViewControllers/ViewController.swift
@@ -10,7 +10,12 @@ import UIKit
 import Shinkansen
 
 class ViewController: UITableViewController {
-    private let shinkansen = TableViewShinkansen()
+
+    enum Section {
+        case fruits
+    }
+
+    private let shinkansen = TableViewShinkansen<Section>()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -24,8 +29,8 @@ class ViewController: UITableViewController {
     }
 
     private func configureSections() {
-        let fruitsSection = shinkansen.createSection(
-            from: ArrayBackedDataSource(items: ["Apple", "Banana"]),
+        let fruitsSection = TableViewDataSourceSection(
+            dataSource: ArrayBackedDataSource(items: ["Apple", "Banana"]),
             cellConfigurator: { tableView, fruit, indexPath in
                 let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
                 cell.textLabel?.text = fruit
@@ -38,5 +43,7 @@ class ViewController: UITableViewController {
             let detailViewController = DetailViewController(title: fruit)
             self?.navigationController?.pushViewController(detailViewController, animated: true)
         }
+
+        shinkansen.connectSection(fruitsSection, identifiedBy: .fruits)
     }
 }

--- a/Shinkansen.xcodeproj/project.pbxproj
+++ b/Shinkansen.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		F4E0A1D8221C6E4F00F3CEED /* TableViewShinkansen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E0A1D7221C6E4F00F3CEED /* TableViewShinkansen.swift */; };
 		F4E0A1EC221C982200F3CEED /* SectionDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E0A1EB221C982200F3CEED /* SectionDataSource.swift */; };
 		F4E0A1EE221C996500F3CEED /* TableViewDataSourceSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E0A1ED221C996500F3CEED /* TableViewDataSourceSection.swift */; };
+		F4EDF5FF235DDD150083FD01 /* Conductor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4EDF5FE235DDD150083FD01 /* Conductor.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -46,6 +47,7 @@
 		F4E0A1D7221C6E4F00F3CEED /* TableViewShinkansen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewShinkansen.swift; sourceTree = "<group>"; };
 		F4E0A1EB221C982200F3CEED /* SectionDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionDataSource.swift; sourceTree = "<group>"; };
 		F4E0A1ED221C996500F3CEED /* TableViewDataSourceSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewDataSourceSection.swift; sourceTree = "<group>"; };
+		F4EDF5FE235DDD150083FD01 /* Conductor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Conductor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -110,6 +112,7 @@
 			isa = PBXGroup;
 			children = (
 				F4C5F9FF2233C0EF00080046 /* ChangeSet.swift */,
+				F4EDF5FE235DDD150083FD01 /* Conductor.swift */,
 				F4C5F9FD2233BF9000080046 /* DataSourceConductor.swift */,
 				F4E0A1D0221C6D9E00F3CEED /* SectionConductor.swift */,
 				F4E0A1EB221C982200F3CEED /* SectionDataSource.swift */,
@@ -223,6 +226,7 @@
 				F404CD782226FD2400A0566E /* CollectionViewSection.swift in Sources */,
 				F4D3381A22ABC20F002B154F /* ShinkansenView.swift in Sources */,
 				F4E0A1EE221C996500F3CEED /* TableViewDataSourceSection.swift in Sources */,
+				F4EDF5FF235DDD150083FD01 /* Conductor.swift in Sources */,
 				F4D3381C22ABC28A002B154F /* UITableView+ShinkansenView.swift in Sources */,
 				F404CD7C2226FF9400A0566E /* Shinkansen.swift in Sources */,
 				F4E0A1EC221C982200F3CEED /* SectionDataSource.swift in Sources */,

--- a/Sources/Shinkansen/Conductor.swift
+++ b/Sources/Shinkansen/Conductor.swift
@@ -1,0 +1,45 @@
+//
+//  Conductor.swift
+//  Shinkansen iOS
+//
+//  Created by Simon Jarbrant on 2019-10-21.
+//
+
+import Foundation
+
+class Conductor<SectionIdentifier>: SectionConductor where SectionIdentifier: Hashable {
+
+    typealias DataSourceUpdateClosure = () -> Void
+    typealias ReloadClosure = (SectionIdentifier) -> Void
+    typealias ItemReloadClosure = (SectionIdentifier, _ indices: IndexSet, _ dataSourceUpdateClosure: DataSourceUpdateClosure) -> Void
+    typealias PerformChangesClosure = (SectionIdentifier, _ changes: ChangeSet, _ dataSourceUpdateClosure: DataSourceUpdateClosure) -> Void
+
+    private let reloadClosure: ReloadClosure
+    private let itemReloadClosure: ItemReloadClosure
+    private let performChangesClosure: PerformChangesClosure
+
+    let sectionIdentifier: SectionIdentifier
+
+    init(sectionIdentifier: SectionIdentifier,
+         reloadClosure: @escaping Conductor<SectionIdentifier>.ReloadClosure,
+         itemReloadClosure: @escaping Conductor<SectionIdentifier>.ItemReloadClosure,
+         performChangesClosure: @escaping Conductor<SectionIdentifier>.PerformChangesClosure) {
+
+        self.sectionIdentifier = sectionIdentifier
+        self.reloadClosure = reloadClosure
+        self.itemReloadClosure = itemReloadClosure
+        self.performChangesClosure = performChangesClosure
+    }
+
+    func reloadSection(_ section: ShinkansenSection) {
+        reloadClosure(sectionIdentifier)
+    }
+
+    func reloadItems(at indices: [Int], for section: ShinkansenSection, dataSourceUpdateClosure: () -> Void) {
+        itemReloadClosure(sectionIdentifier, IndexSet(indices), dataSourceUpdateClosure)
+    }
+
+    func performChanges(_ changes: ChangeSet, for section: ShinkansenSection, dataSourceUpdateClosure: () -> Void) {
+        performChangesClosure(sectionIdentifier, changes, dataSourceUpdateClosure)
+    }
+}

--- a/Sources/Shinkansen/Conductor.swift
+++ b/Sources/Shinkansen/Conductor.swift
@@ -32,14 +32,20 @@ class Conductor<SectionIdentifier>: SectionConductor where SectionIdentifier: Ha
     }
 
     func reloadSection(_ section: ShinkansenSection) {
-        reloadClosure(sectionIdentifier)
+        DispatchQueue.main.async { [reloadClosure, sectionIdentifier] in
+            reloadClosure(sectionIdentifier)
+        }
     }
 
-    func reloadItems(at indices: [Int], for section: ShinkansenSection, dataSourceUpdateClosure: () -> Void) {
-        itemReloadClosure(sectionIdentifier, IndexSet(indices), dataSourceUpdateClosure)
+    func reloadItems(at indices: [Int], for section: ShinkansenSection, dataSourceUpdateClosure: @escaping () -> Void) {
+        DispatchQueue.main.async { [itemReloadClosure, sectionIdentifier] in
+            itemReloadClosure(sectionIdentifier, IndexSet(indices), dataSourceUpdateClosure)
+        }
     }
 
-    func performChanges(_ changes: ChangeSet, for section: ShinkansenSection, dataSourceUpdateClosure: () -> Void) {
-        performChangesClosure(sectionIdentifier, changes, dataSourceUpdateClosure)
+    func performChanges(_ changes: ChangeSet, for section: ShinkansenSection, dataSourceUpdateClosure: @escaping () -> Void) {
+        DispatchQueue.main.async { [performChangesClosure, sectionIdentifier] in
+            performChangesClosure(sectionIdentifier, changes, dataSourceUpdateClosure)
+        }
     }
 }

--- a/Sources/Shinkansen/DataSourceConductor.swift
+++ b/Sources/Shinkansen/DataSourceConductor.swift
@@ -10,6 +10,6 @@ import Foundation
 public protocol DataSourceConductor: AnyObject {
     typealias UpdateClosure = () -> Void
 
-    func reloadItems(at indices: [Int], updateClosure: UpdateClosure)
-    func performChanges(_ changes: ChangeSet, updateClosure: UpdateClosure)
+    func reloadItems(at indices: [Int], updateClosure: @escaping UpdateClosure)
+    func performChanges(_ changes: ChangeSet, updateClosure: @escaping UpdateClosure)
 }

--- a/Sources/Shinkansen/SectionConductor.swift
+++ b/Sources/Shinkansen/SectionConductor.swift
@@ -11,6 +11,6 @@ public protocol SectionConductor: AnyObject {
     typealias UpdateClosure = () -> Void
 
     func reloadSection(_ section: ShinkansenSection)
-    func reloadItems(at indices: [Int], for section: ShinkansenSection, dataSourceUpdateClosure: UpdateClosure)
-    func performChanges(_ changes: ChangeSet, for section: ShinkansenSection, dataSourceUpdateClosure: UpdateClosure)
+    func reloadItems(at indices: [Int], for section: ShinkansenSection, dataSourceUpdateClosure: @escaping UpdateClosure)
+    func performChanges(_ changes: ChangeSet, for section: ShinkansenSection, dataSourceUpdateClosure: @escaping UpdateClosure)
 }

--- a/Sources/Shinkansen/Shinkansen.swift
+++ b/Sources/Shinkansen/Shinkansen.swift
@@ -7,8 +7,42 @@
 
 import Foundation
 
-public protocol Shinkansen {
+public protocol Shinkansen: AnyObject {
     associatedtype View: ShinkansenView
+    associatedtype SectionIdentifier: Hashable
 
     var view: View? { get set }
+
+    func indexOfSection(_ identifier: SectionIdentifier) -> Int?
+    func sectionIdentifier(for index: Int) -> SectionIdentifier?
+}
+
+extension Shinkansen {
+    func createConductor(for sectionIdentifier: SectionIdentifier) -> Conductor<SectionIdentifier> {
+        return Conductor(
+            sectionIdentifier: sectionIdentifier,
+            reloadClosure: { [weak self] identifier in
+                guard let sectionIndex = self?.indexOfSection(identifier) else {
+                    return
+                }
+
+                self?.view?.reloadSection(at: sectionIndex)
+
+            }, itemReloadClosure: { [weak self] identifier, indices, dataSourceUpdateClosure in
+                guard let sectionIndex = self?.indexOfSection(identifier) else {
+                    dataSourceUpdateClosure()
+                    return
+                }
+
+                self?.view?.reloadItems(at: indices, inSection: sectionIndex, dataSourceUpdateClosure: dataSourceUpdateClosure)
+
+            }, performChangesClosure: { [weak self] identifier, changes, dataSourceUpdateClosure in
+                guard let sectionIndex = self?.indexOfSection(identifier) else {
+                    dataSourceUpdateClosure()
+                    return
+                }
+
+                self?.view?.applyChanges(changes, inSection: sectionIndex, dataSourceUpdateClosure: dataSourceUpdateClosure)
+        })
+    }
 }

--- a/Sources/Shinkansen/ShinkansenSection.swift
+++ b/Sources/Shinkansen/ShinkansenSection.swift
@@ -8,13 +8,5 @@
 import Foundation
 
 public protocol ShinkansenSection: AnyObject {
-    var id: Int { get }
-
     func setConductor(_ conductor: SectionConductor)
-}
-
-public extension ShinkansenSection {
-    var id: Int {
-        return ObjectIdentifier(self).hashValue
-    }
 }

--- a/Sources/Shinkansen/ShinkansenView.swift
+++ b/Sources/Shinkansen/ShinkansenView.swift
@@ -9,4 +9,8 @@ import Foundation
 
 public protocol ShinkansenView: AnyObject {
     associatedtype CellType
+
+    func reloadSection(at index: Int)
+    func reloadItems(at indices: IndexSet, inSection section: Int, dataSourceUpdateClosure: () -> Void)
+    func applyChanges(_ changes: ChangeSet, inSection section: Int, dataSourceUpdateClosure: () -> Void)
 }

--- a/Sources/Shinkansen/iOS/UICollectionView+ShinkansenView.swift
+++ b/Sources/Shinkansen/iOS/UICollectionView+ShinkansenView.swift
@@ -9,4 +9,46 @@ import UIKit
 
 extension UICollectionView: ShinkansenView {
     public typealias CellType = UICollectionViewCell
+
+    public func reloadSection(at index: Int) {
+        let indexSet = IndexSet([index])
+        reloadSections(indexSet)
+    }
+
+    public func reloadItems(at indices: IndexSet, inSection section: Int, dataSourceUpdateClosure: () -> Void) {
+        guard !indices.isEmpty else { return }
+
+        performBatchUpdates({
+            // Allow the data source to update
+            dataSourceUpdateClosure()
+
+            // Perform UICollectionView updates
+            let reloadIndexPaths = indices.map { IndexPath(row: $0, section: section) }
+            reloadItems(at: reloadIndexPaths)
+        })
+    }
+
+    public func applyChanges(_ changes: ChangeSet, inSection section: Int, dataSourceUpdateClosure: () -> Void) {
+        let insertionIndexPaths = changes.insertions.map { IndexPath(row: $0, section: section) }
+        let deletionIndexPaths = changes.deletions.map { IndexPath(row: $0, section: section) }
+        let moveIndexPaths = changes.moves.map { move -> (origin: IndexPath, destination: IndexPath) in
+            return (
+                origin: IndexPath(row: move.from, section: section),
+                destination: IndexPath(row: move.to, section: section)
+            )
+        }
+
+        performBatchUpdates({
+            // Allow the data source to update
+            dataSourceUpdateClosure()
+
+            // Perform UICollectionView updates
+            deleteItems(at: deletionIndexPaths)
+            insertItems(at: insertionIndexPaths)
+
+            for move in moveIndexPaths {
+                moveItem(at: move.origin, to: move.destination)
+            }
+        })
+    }
 }

--- a/Sources/Shinkansen/iOS/UICollectionView/CollectionViewDataSourceSection.swift
+++ b/Sources/Shinkansen/iOS/UICollectionView/CollectionViewDataSourceSection.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-public final class CollectionViewDataSourceSection<DataSource>: NSObject, CollectionViewSection, DataSourceConductor where DataSource: SectionDataSource {
+public final class CollectionViewDataSourceSection<DataSource>: NSObject, CollectionViewSection where DataSource: SectionDataSource {
 
     public typealias SupplementaryViewConfigurator = (UICollectionView, IndexPath) -> UICollectionReusableView
     public typealias SupplementaryViewSizeClosure = (UICollectionView) -> CGSize
@@ -111,7 +111,7 @@ extension CollectionViewDataSourceSection {
 }
 
 // MARK: - DataSourceConductor
-extension CollectionViewDataSourceSection {
+extension CollectionViewDataSourceSection: DataSourceConductor {
     public func reloadItems(at indices: [Int], updateClosure: UpdateClosure) {
         conductor?.reloadItems(at: indices, for: self, dataSourceUpdateClosure: updateClosure)
     }

--- a/Sources/Shinkansen/iOS/UICollectionView/CollectionViewDataSourceSection.swift
+++ b/Sources/Shinkansen/iOS/UICollectionView/CollectionViewDataSourceSection.swift
@@ -112,11 +112,11 @@ extension CollectionViewDataSourceSection {
 
 // MARK: - DataSourceConductor
 extension CollectionViewDataSourceSection: DataSourceConductor {
-    public func reloadItems(at indices: [Int], updateClosure: UpdateClosure) {
+    public func reloadItems(at indices: [Int], updateClosure: @escaping UpdateClosure) {
         conductor?.reloadItems(at: indices, for: self, dataSourceUpdateClosure: updateClosure)
     }
 
-    public func performChanges(_ changes: ChangeSet, updateClosure: UpdateClosure) {
+    public func performChanges(_ changes: ChangeSet, updateClosure: @escaping UpdateClosure) {
         conductor?.performChanges(changes, for: self, dataSourceUpdateClosure: updateClosure)
     }
 }

--- a/Sources/Shinkansen/iOS/UICollectionView/CollectionViewShinkansen.swift
+++ b/Sources/Shinkansen/iOS/UICollectionView/CollectionViewShinkansen.swift
@@ -7,8 +7,12 @@
 
 import UIKit
 
-public class CollectionViewShinkansen: NSObject, Shinkansen {
-    public private(set) var sections: [CollectionViewSection] = []
+public class CollectionViewShinkansen<SectionIdentifier>: NSObject, Shinkansen, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout, UICollectionViewDataSource
+where SectionIdentifier: Hashable {
+
+    private var sections: [SectionIdentifier: CollectionViewSection] = [:]
+    private var sectionOrder: [SectionIdentifier] = []
+    private var conductors: [Conductor<SectionIdentifier>] = []
 
     public weak var view: UICollectionView? {
         didSet {
@@ -18,40 +22,37 @@ public class CollectionViewShinkansen: NSObject, Shinkansen {
         }
     }
 
-    public func connectSection(_ section: CollectionViewSection) {
-        section.setConductor(self)
+    public func connectSection(_ section: CollectionViewSection, identifiedBy identifier: SectionIdentifier) {
+        let conductor = createConductor(for: identifier)
+
+        section.setConductor(conductor)
+        conductors.append(conductor)
+
+        let updateClosure: () -> Void = {
+            self.sections[identifier] = section
+            self.sectionOrder.append(identifier)
+        }
 
         guard let collectionView = view else {
-            sections.append(section)
+            updateClosure()
             return
         }
 
         collectionView.performBatchUpdates({
-            let sectionIndex = sections.count
-            sections.append(section)
+            updateClosure()
+            let sectionIndex = indexOfSection(identifier)!
             collectionView.insertSections(IndexSet(integer: sectionIndex))
         })
     }
 
-    @discardableResult
-    public func createSection<DataSource: SectionDataSource>(
-        from dataSource: DataSource,
-        cellConfigurator: @escaping CollectionViewDataSourceSection<DataSource>.CellConfigurator) -> CollectionViewDataSourceSection<DataSource> {
-
-        let section = CollectionViewDataSourceSection(dataSource: dataSource, cellConfigurator: cellConfigurator)
-        connectSection(section)
-
-        return section
-    }
-
-    public func moveSection(_ section: CollectionViewSection, to destinationIndex: Int) {
-        guard let sectionIndex = sections.firstIndex(where: { $0.id == section.id }) else {
+    public func moveSection(_ identifier: SectionIdentifier, to destinationIndex: Int) {
+        guard let sectionIndex = sectionOrder.firstIndex(of: identifier) else {
             return
         }
 
         let updateClosure: () -> Void = {
-            self.sections.remove(at: sectionIndex)
-            self.sections.insert(section, at: destinationIndex)
+            self.sectionOrder.remove(at: sectionIndex)
+            self.sectionOrder.insert(identifier, at: destinationIndex)
         }
 
         guard let collectionView = view else {
@@ -66,13 +67,15 @@ public class CollectionViewShinkansen: NSObject, Shinkansen {
         })
     }
 
-    public func removeSection(_ section: CollectionViewSection) {
-        guard let sectionIndex = sections.firstIndex(where: { $0.id == section.id }) else {
+    public func removeSection(_ identifier: SectionIdentifier) {
+        guard let sectionIndex = sectionOrder.firstIndex(of: identifier) else {
             return
         }
 
         let updateClosure: () -> Void = {
-            self.sections.remove(at: sectionIndex)
+            self.sections.removeValue(forKey: identifier)
+            self.sectionOrder.remove(at: sectionIndex)
+            self.conductors.removeAll(where: { $0.sectionIdentifier == identifier })
         }
 
         guard let collectionView = view else {
@@ -80,139 +83,99 @@ public class CollectionViewShinkansen: NSObject, Shinkansen {
             return
         }
 
-        let indexSet = IndexSet(integer: sectionIndex)
-
         collectionView.performBatchUpdates({
             updateClosure()
+
+            let indexSet = IndexSet(integer: sectionIndex)
             collectionView.deleteSections(indexSet)
         })
     }
-}
 
-// MARK: - UICollectionViewDelegateFlowLayout
-extension CollectionViewShinkansen: UICollectionViewDelegateFlowLayout {
+    public func indexOfSection(_ identifier: SectionIdentifier) -> Int? {
+        return sectionOrder.firstIndex(of: identifier)
+    }
+
+    public func sectionIdentifier(for index: Int) -> SectionIdentifier? {
+        guard sectionOrder.indices.contains(index) else {
+            return nil
+        }
+
+        return sectionOrder[index]
+    }
+
+    public func section(at index: Int) -> CollectionViewSection? {
+        guard sectionOrder.indices.contains(index) else {
+            return nil
+        }
+
+        let sectionIdentifier = sectionOrder[index]
+        return sections[sectionIdentifier]
+    }
+
+    // MARK: - UICollectionViewDelegateFlowLayout
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let section = sections[indexPath.section]
+        let section = self.section(at: indexPath.section)!
         let localIndexPath = IndexPath(row: indexPath.row, section: 0)
+
         return section.sizeForItem(in: collectionView, at: localIndexPath)
     }
 
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        return sections[section].sectionInsets
+        return self.section(at: section)!.sectionInsets
     }
 
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        return sections[section].minimumLineSpacing
+        return self.section(at: section)!.minimumLineSpacing
     }
 
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
-        return sections[section].minimumInteritemSpacing
+        return self.section(at: section)!.minimumInteritemSpacing
     }
 
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-        let section = sections[section]
-        return section.sizeForSupplementaryView(
-            ofKind: UICollectionView.elementKindSectionHeader,
-            in: collectionView)
+        let section = self.section(at: section)!
+
+        return section.sizeForSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader, in: collectionView)
     }
 
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
-        let section = sections[section]
-        return section.sizeForSupplementaryView(
-            ofKind: UICollectionView.elementKindSectionFooter,
-            in: collectionView)
-    }
-}
+        let section = self.section(at: section)!
 
-// MARK: - UICollectionViewDataSource
-extension CollectionViewShinkansen: UICollectionViewDataSource {
+        return section.sizeForSupplementaryView(ofKind: UICollectionView.elementKindSectionFooter, in: collectionView)
+    }
+
+    // MARK: - UICollectionViewDataSource
     public func numberOfSections(in collectionView: UICollectionView) -> Int {
         return sections.count
     }
 
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        let section = sections[section]
+        let sectionIdentifier = sectionOrder[section]
+        let section = sections[sectionIdentifier]!
+
         return section.collectionView(collectionView, numberOfItemsInSection: 0)
     }
 
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let section = sections[indexPath.section]
+        let section = self.section(at: indexPath.section)!
         let localIndexPath = IndexPath(row: indexPath.row, section: 0)
+
         return section.collectionView(collectionView, cellForItemAt: localIndexPath)
     }
 
     public func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-        let section = sections[indexPath.section]
+        let section = self.section(at: indexPath.section)!
         if let view = section.collectionView?(collectionView, viewForSupplementaryElementOfKind: kind, at: indexPath) {
             return view
         } else {
             return UICollectionReusableView()
         }
     }
-}
 
-// MARK: - UICollectionViewDelegate
-extension CollectionViewShinkansen: UICollectionViewDelegate {
+    // MARK: - UICollectionViewDelegate
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let section = sections[indexPath.section]
+        let section = self.section(at: indexPath.section)!
         let localIndexPath = IndexPath(row: indexPath.row, section: 0)
         section.collectionView?(collectionView, didSelectItemAt: localIndexPath)
-    }
-}
-
-// MARK: - SectionConductor
-extension CollectionViewShinkansen: SectionConductor {
-    public func reloadSection(_ section: ShinkansenSection) {
-        guard let collectionView = view,
-            let sectionIndex = sections.firstIndex(where: { $0.id == section.id })
-            else { return }
-
-        let sectionIndexSet = IndexSet([sectionIndex])
-        collectionView.reloadSections(sectionIndexSet)
-    }
-
-    public func reloadItems(at indices: [Int], for section: ShinkansenSection, dataSourceUpdateClosure: () -> Void) {
-        guard !indices.isEmpty else {
-            return
-        }
-
-        guard let collectionView = view,
-            let sectionIndex = sections.firstIndex(where: { $0.id == section.id })
-            else { return }
-
-        let reloadIndexPaths = indices.map { IndexPath(row: $0, section: sectionIndex) }
-
-        collectionView.performBatchUpdates({
-            // Allow the data source to update
-            dataSourceUpdateClosure()
-
-            // Perform UICollectionView updates
-            collectionView.reloadItems(at: reloadIndexPaths)
-        })
-    }
-
-    public func performChanges(_ changes: ChangeSet, for section: ShinkansenSection, dataSourceUpdateClosure: () -> Void) {
-        guard let collectionView = view,
-            let sectionIndex = sections.firstIndex(where: { $0.id == section.id })
-            else { return }
-
-        let insertIndexPaths = changes.insertions.map { IndexPath(row: $0, section: sectionIndex) }
-        let deletionIndexPaths = changes.deletions.map { IndexPath(row: $0, section: sectionIndex) }
-        let moveIndexPaths = changes.moves.map { move -> (IndexPath, IndexPath) in
-            return (IndexPath(row: move.from, section: sectionIndex), IndexPath(row: move.to, section: sectionIndex))
-        }
-
-        collectionView.performBatchUpdates({
-            // Allow the data source to update
-            dataSourceUpdateClosure()
-
-            // Perform UICollectionView updates
-            collectionView.deleteItems(at: deletionIndexPaths)
-            collectionView.insertItems(at: insertIndexPaths)
-
-            for move in moveIndexPaths {
-                collectionView.moveItem(at: move.0, to: move.1)
-            }
-        })
     }
 }

--- a/Sources/Shinkansen/iOS/UITableView+ShinkansenView.swift
+++ b/Sources/Shinkansen/iOS/UITableView+ShinkansenView.swift
@@ -8,5 +8,48 @@
 import UIKit
 
 extension UITableView: ShinkansenView {
+
     public typealias CellType = UITableViewCell
+
+    public func reloadSection(at index: Int) {
+        let indexSet = IndexSet([index])
+        reloadSections(indexSet, with: .automatic)
+    }
+
+    public func reloadItems(at indices: IndexSet, inSection section: Int, dataSourceUpdateClosure: () -> Void) {
+        guard !indices.isEmpty else { return }
+
+        performBatchUpdates({
+            // Allow the data source to update
+            dataSourceUpdateClosure()
+
+            // Perform UITableView updates
+            let reloadIndexPaths = indices.map { IndexPath(row: $0, section: section) }
+            reloadRows(at: reloadIndexPaths, with: .automatic)
+        })
+    }
+
+    public func applyChanges(_ changes: ChangeSet, inSection section: Int, dataSourceUpdateClosure: () -> Void) {
+        let insertIndexPaths = changes.insertions.map { IndexPath(row: $0, section: section) }
+        let deletionIndexPaths = changes.deletions.map { IndexPath(row: $0, section: section) }
+        let moveIndexPaths = changes.moves.map { move -> (origin: IndexPath, destination: IndexPath) in
+            return (
+                origin: IndexPath(row: move.from, section: section),
+                destination: IndexPath(row: move.to, section: section)
+            )
+        }
+
+        performBatchUpdates({
+            // Allow the data source to update
+            dataSourceUpdateClosure()
+
+            // Perform UITableView updates
+            deleteRows(at: deletionIndexPaths, with: .automatic)
+            insertRows(at: insertIndexPaths, with: .automatic)
+
+            for move in moveIndexPaths {
+                moveRow(at: move.origin, to: move.destination)
+            }
+        })
+    }
 }

--- a/Sources/Shinkansen/iOS/UITableView/TableViewDataSourceSection.swift
+++ b/Sources/Shinkansen/iOS/UITableView/TableViewDataSourceSection.swift
@@ -60,11 +60,11 @@ public final class TableViewDataSourceSection<DataSource>: NSObject, TableViewSe
 
 // MARK: - DataSourceConductor
 extension TableViewDataSourceSection: DataSourceConductor {
-    public func reloadItems(at indices: [Int], updateClosure: () -> Void) {
+    public func reloadItems(at indices: [Int], updateClosure: @escaping UpdateClosure) {
         conductor?.reloadItems(at: indices, for: self, dataSourceUpdateClosure: updateClosure)
     }
 
-    public func performChanges(_ changes: ChangeSet, updateClosure: () -> Void) {
+    public func performChanges(_ changes: ChangeSet, updateClosure: @escaping UpdateClosure) {
         conductor?.performChanges(changes, for: self, dataSourceUpdateClosure: updateClosure)
     }
 }

--- a/Sources/Shinkansen/iOS/UITableView/TableViewDataSourceSection.swift
+++ b/Sources/Shinkansen/iOS/UITableView/TableViewDataSourceSection.swift
@@ -35,11 +35,7 @@ public final class TableViewDataSourceSection<DataSource>: NSObject, TableViewSe
         dataSource.setConductor(self)
     }
 
-    public func registerCells(in tableView: UITableView) {
-        // Unused
-    }
-
-    // MARK: - UITableViewDataSource
+    // MARK: UITableViewDataSource
 
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return dataSource.items.count
@@ -54,7 +50,7 @@ public final class TableViewDataSourceSection<DataSource>: NSObject, TableViewSe
         return sectionHeader
     }
 
-    // MARK: - UITableViewDelegate
+    // MARK: UITableViewDelegate
 
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let item = dataSource.items[indexPath.row]


### PR DESCRIPTION
The basic idea for this pitch is very simple (and similar to the new DiffableDatasource APIs from Apple); let the user specify section identifiers when setting up a `CollectionViewShinkansen` or `TableViewShinkansen`. This makes the API easier to use in a number of ways, since the user doesn't have to keep track of indices of individual sections or directly hold references to the sections themselves.

I also tried to simplify (and unify, where possible) a lot of the underlying code to make the library more maintainable. 

Please provide feedback if you find something that can be improved 🙂 